### PR TITLE
Fix Auto Release Builder Windows output path

### DIFF
--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -76,7 +76,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: kodair-windows-installer
-          path: Output/Kodair_Installer.exe
+          path: Output/KodairInstaller.exe
 
   publish-release:
     name: Draft GitHub Release
@@ -108,6 +108,6 @@ jobs:
           body: "Automated Native Release Pipeline triggered by version increment. \n\nIncludes Android Edge-To-Edge fixes, YouTube Autoplay configurations, and full Windows Installer integrity."
           files: |
             release-binaries/app-release.apk
-            release-binaries/Kodair_Installer.exe
+            release-binaries/KodairInstaller.exe
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/kodair_setup.iss
+++ b/kodair_setup.iss
@@ -6,8 +6,8 @@ DefaultDirName={autopf}\Kodair
 ; It forces the installer to run without requiring Admin rights,
 ; and installs the app inside the user's Local AppData directory.
 PrivilegesRequired=lowest
-OutputDir=installer
-OutputBaseFilename=KodairBrowser-Setup
+OutputDir=Output
+OutputBaseFilename=KodairInstaller
 Compression=lzma2
 SolidCompression=yes
 SetupIconFile=kodair_browser\windows\runner\resources\app_icon.ico


### PR DESCRIPTION
Align the Inno Setup installer output with the GitHub Actions workflow so the release job can find the Windows installer at Output/KodairInstaller.exe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Windows installer build configuration, including output filename and path adjustments.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Farwalker3/kodair/pull/127)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->