### PR TITLE
chore: bump version to trigger Auto Release Builder

### DIFF
--- a/kodair_browser/pubspec.yaml
+++ b/kodair_browser/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.7+7
+version: 1.0.8+8
 
 environment:
   sdk: ^3.10.4


### PR DESCRIPTION
Bump kodair_browser/pubspec.yaml from 1.0.7+7 to 1.0.8+8 so the Auto Release Builder workflow triggers on merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Application version updated to 1.0.8 for release.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Farwalker3/kodair/pull/128)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->